### PR TITLE
Incompatible with eslint 10.x

### DIFF
--- a/src/lib/rules/sort-sx-properties.ts
+++ b/src/lib/rules/sort-sx-properties.ts
@@ -30,7 +30,7 @@ const rule: RuleModule = {
     // Collect local identifiers for createStyles imported from MUI packages
     const muiCreateStylesNames = new Set<string>();
     try {
-      const ast: any = (context.getSourceCode() as any).ast;
+      const ast: any = (context.sourceCode as any).ast;
       if (ast && Array.isArray(ast.body)) {
         for (const node of ast.body) {
           if (

--- a/src/lib/utils/checkAndReport.ts
+++ b/src/lib/utils/checkAndReport.ts
@@ -95,7 +95,7 @@ export function checkAndReport(
 
   // (no global sorted list; sorting will be applied per segment only)
 
-  const sourceCode = context.getSourceCode();
+  const sourceCode = context.sourceCode;
 
   // Analyze for simple safe case
   const objectText = sourceCode.getText(node);


### PR DESCRIPTION
### Issue - Getting the following error when using eslint 10.2.1
```
Oops! Something went wrong! :(

ESLint: 10.2.1

TypeError: context.getSourceCode is not a function
```

### Reproduce Steps
```
$ git clone https://github.com/sytnikovzp/eslint-plugin-mui-sx-order.git
$ cd eslint-plugin-mui-sx-order
$ sed -i 's/"eslint": ">=8"/"eslint": ">=10"/' package.json
$ npm install
$ npm run test
> eslint-plugin-mui-sx-order@1.7.0 test
> npm run build && mocha tests/**/*.test.js


> eslint-plugin-mui-sx-order@1.7.0 build
> tsc

src/lib/rules/sort-sx-properties.ts:33:33 - error TS2551: Property 'getSourceCode' does not exist on type 'RuleContext'. Did you mean 'sourceCode'?

33       const ast: any = (context.getSourceCode() as any).ast;
                                   ~~~~~~~~~~~~~

  node_modules/@eslint/core/dist/esm/types.d.ts:258:5
    258     sourceCode: Options["Code"];
            ~~~~~~~~~~
    'sourceCode' is declared here.

src/lib/utils/checkAndReport.ts:98:30 - error TS2551: Property 'getSourceCode' does not exist on type 'RuleContext'. Did you mean 'sourceCode'?

98   const sourceCode = context.getSourceCode();
                                ~~~~~~~~~~~~~

  node_modules/@eslint/core/dist/esm/types.d.ts:258:5
    258     sourceCode: Options["Code"];
            ~~~~~~~~~~
    'sourceCode' is declared here.


Found 2 errors in 2 files.

Errors  Files
     1  src/lib/rules/sort-sx-properties.ts:33
     1  src/lib/utils/checkAndReport.ts:98
```

### Preliminary RCA

The previously deprecated RuleContext.getSourCode() is [removed since eslint 10.0.0](https://eslint.org/blog/2026/02/eslint-v10.0.0-released/#removed-deprecated-rule-context-members)

### Proposed Solution

Replace `context.getSourceCode()` with `context.sourceCode`